### PR TITLE
Mark MyFlutterCrypto as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "only-arches": ["x86_64"]
+    "only-arches": ["x86_64"],
+    "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
This application uses an old runtime that was marked as end-of-life (EOL) two years ago.

https://github.com/flathub/com.github.tglima.Myfluttercrypto/issues/2